### PR TITLE
Add PHP 8.2 support for Magento 2.4.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "magento/framework": "~102.0||~103.0",
         "magento/module-catalog": "~103.0||~104.0",
         "magento/module-customer": "~102.0||~103.0",
-        "php": "~7.3.0||~7.4.0||~8.1.0"
+        "php": "~7.3.0||~7.4.0||~8.1.0||~8.2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~6.5||~9.5.0",


### PR DESCRIPTION
Add PHP 8.2 support for Magento 2.4.6